### PR TITLE
[hello-world] Edit do-nothing port without bumping version

### DIFF
--- a/ports/hello-world/portfile.cmake
+++ b/ports/hello-world/portfile.cmake
@@ -1,3 +1,5 @@
 # A do-nothing port: it installs no files and only exists to demonstrate the
 # check-for-common-mistakes workflow.
+# This edit changes the port without bumping the version, exercising the
+# PR-against-PR case where the in-progress version's git-tree is overwritten.
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/versions/h-/hello-world.json
+++ b/versions/h-/hello-world.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e94f8a062c78cb02120aa664094bd734e1883dcd",
+      "git-tree": "eb16ee91e3de3168b73336ff4276010582fa9afb",
       "version": "1.0.0",
       "port-version": 0
     }


### PR DESCRIPTION
Demonstrates the PR-against-PR case: the port's git-tree changes but the version stays 1.0.0, so the version database entry's git-tree is overwritten rather than a new version being added.

Authored-by: Claude Opus 4.8